### PR TITLE
php: output raw file iff client is curl

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,6 +56,12 @@ if (isset($_POST['t'])) {
     file_put_contents($path, $_POST['t']);
     die();
 }
+
+if (preg_match('/^curl\//', $_SERVER ['HTTP_USER_AGENT'])) {
+    // Output raw file iff client is curl.
+    echo file_get_contents($path);
+    die();
+}
 ?><!DOCTYPE html>
 <html>
 <head>

--- a/index.php
+++ b/index.php
@@ -57,9 +57,10 @@ if (isset($_POST['t'])) {
     die();
 }
 
-if (preg_match('/^curl\//', $_SERVER ['HTTP_USER_AGENT'])) {
-    // Output raw file iff client is curl.
-    echo file_get_contents($path);
+if (strpos($_SERVER['HTTP_USER_AGENT'], 'curl') === 0) {
+
+    // Output raw file if client is curl.
+    print file_get_contents($path);
     die();
 }
 ?><!DOCTYPE html>


### PR DESCRIPTION
Sometimes, we intend to share notes between web and terminal/console.
In this case, it's better output raw if client is curl.

Signed-off-by: phuslu <phuslu@hotmail.com>