### PR TITLE
Add -Indexes options and document AuthType basic

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,16 @@
+Options -Indexes
 RewriteEngine On
 RewriteRule ^([a-zA-Z0-9]+)$ index.php?f=$1
 
 <IfModule mod_headers.c>
     Header set X-Robots-Tag: "noindex, nofollow"
 </IfModule>
+
+# Uncomment the below lines to enable basic authentication
+# Please note that it is secure only over https
+# See https://httpd.apache.org/docs/2.4/programs/htpasswd.html for generating your .htpasswd
+
+# AuthType basic
+# AuthName "website.name"
+# AuthUserFile "/home/user/update-path-to.htpasswd"
+# Require valid-user

--- a/.htaccess
+++ b/.htaccess
@@ -6,8 +6,8 @@ RewriteRule ^([a-zA-Z0-9]+)$ index.php?f=$1
     Header set X-Robots-Tag: "noindex, nofollow"
 </IfModule>
 
-# Uncomment the below lines to enable basic authentication
-# Please note that it is secure only over https
+# Uncomment the lines below to enable basic authentication.
+# Please note that it is secure only over https.
 # See https://httpd.apache.org/docs/2.4/programs/htpasswd.html for generating your .htpasswd
 
 # AuthType basic


### PR DESCRIPTION
Options -Indexes can save the user in case of software bug (which could originate in rewrite rule or idex.php or apache) that lists the directory.

Basic authentication for personal use can be enabled very easily here. It can be come very handy and it is secure over https.

I tested these changes at notes.ekvastra.in and use it to keep my notes.