### PR TITLE
Update to allow dash/hyphen in note name

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,6 @@
 Options -Indexes
 RewriteEngine On
-RewriteRule ^[a-zA-Z0-9_-]*$ index.php?note=$1
+RewriteRule ^[a-zA-Z0-9_-]+$ index.php?note=$1
 
 <IfModule mod_headers.c>
     Header set X-Robots-Tag: "noindex, nofollow"

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,6 @@
 Options -Indexes
 RewriteEngine On
-RewriteRule ^([a-zA-Z0-9]+)$ index.php?note=$1
+RewriteRule ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)$ index.php?note=$1
 
 <IfModule mod_headers.c>
     Header set X-Robots-Tag: "noindex, nofollow"

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,6 @@
 Options -Indexes
 RewriteEngine On
-RewriteRule ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)$ index.php?note=$1
+RewriteRule ^[a-zA-Z0-9_-]*$ index.php?note=$1
 
 <IfModule mod_headers.c>
     Header set X-Robots-Tag: "noindex, nofollow"

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,6 @@
 Options -Indexes
 RewriteEngine On
-RewriteRule ^[a-zA-Z0-9_-]+$ index.php?note=$1
+RewriteRule ^([a-zA-Z0-9_-]+)$ index.php?note=$1
 
 <IfModule mod_headers.c>
     Header set X-Robots-Tag: "noindex, nofollow"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To enable URL rewriting, put something like this in your configuration file:
 If notepad is in the root directory:
 ```
 location / {
-    rewrite ^/([a-zA-Z0-9]+)$ /index.php?note=$1;
+    rewrite ^/([a-zA-Z0-9_-]+)$ /index.php?note=$1;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ location / {
 
 If notepad is in a subdirectory:
 ```
-location ~* ^/notes/(\w+)$ {
+location ~* ^/notes/([a-zA-Z0-9_-]+)$ {
     try_files $uri /notes/index.php?note=$1;
 }
 ```

--- a/index.php
+++ b/index.php
@@ -8,8 +8,8 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 header('Pragma: no-cache');
 header('Expires: 0');
 
-// If a note's name is not provided or contains non-alphanumeric/non-ASCII characters.
-if (!isset($_GET['note']) || !preg_match('/^[a-zA-Z0-9]+$/', $_GET['note'])) {
+// If a note's name is not provided or contains non-alphanumeric/non-ASCII characters, - or _ allowed.
+if (!isset($_GET['note']) || !preg_match('/^[a-zA-Z0-9_-]+$/', $_GET['note'])) {
 
     // Generate a name with 5 random unambiguous characters. Redirect to it.
     header("Location: $base_url/" . substr(str_shuffle('234579abcdefghjkmnpqrstwxyz'), -5));

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 header('Pragma: no-cache');
 header('Expires: 0');
 
-// If a note's name is not provided or contains non-alphanumeric/non-ASCII characters, - or _ allowed.
+// If a note's name is not provided or contains invalid characters.
 if (!isset($_GET['note']) || !preg_match('/^[a-zA-Z0-9_-]+$/', $_GET['note'])) {
 
     // Generate a name with 5 random unambiguous characters. Redirect to it.


### PR DESCRIPTION
Update to allow note names with a dash or hyphen - this would enable easily readable names if required e.g. 
/notes-roadmap 
/notes-useful-links 
/notes-issues, etc.    I'm using this on my install so hope it helps someone else.  Dom