### PR TITLE
Add optional encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-Minimalist Web Notepad
-======================
+# Minimalist Web Notepad
 
 This is an open source clone of notepad.cc, which is now defunct.
 
 See demo at https://notes.orga.cat or https://notes.orga.cat/whatever.
 
 
-Installation
-------------
+## Installation
 
 At the top of `index.php` file, change `$base_url` variable to point to your
 site.
@@ -45,7 +43,7 @@ docker build -t minimalist-web-notepad .
 
 Start the container:
 ```
-docker run -itd --name minimalist-web-notepad -p 80:80 minimalist-web-notepad
+docker run -it --name minimalist-web-notepad -p 80:80 minimalist-web-notepad
 ```
 
 Alternatively, docker-compose can also be used:
@@ -53,8 +51,14 @@ Alternatively, docker-compose can also be used:
 docker-compose up -d
 ```
 
-Screenshots
------------
+#### Environment variables
+
+`MWN_BASE_URL`    The base URL for redirection and assets. Defaults to ''.
+`MWN_SAVE_PATH`   The path to save the notes to. Relative paths are relative to `index.php` location.
+`MWN_ENCRYPTION`  Enable encryption when not empty.
+`MWN_CRYPTO_SALT` Random static salt to use for encryption.
+
+## Screenshots
 
 ![Firefox](https://orga.cat/sites/default/files/images/firefox.png)
 
@@ -67,8 +71,7 @@ Screenshots
 ![Firefox Android](https://orga.cat/sites/default/files/images/android_firefox.png)
 
 
-Copyright and license
----------------------
+## Copyright and license
 
 Copyright 2012 Pere Orga <pere@orga.cat>
 

--- a/crypt.js
+++ b/crypt.js
@@ -1,0 +1,25 @@
+const unambiguousChars = '23456789abcdefghjkmnpqrstwxyz';  // easily human-readable
+async function generatePassword(length) {
+  let password = window.crypto.getRandomValues(new Uint32Array(length));
+  return password.reduce((str,chr)=>str+unambiguousChars[chr%unambiguousChars.length],'');  // chars from unambiguousChars list
+}
+async function deriveKey(password, salt) {
+  let keyMaterial = await window.crypto.subtle.importKey("raw", new TextEncoder().encode(password), "PBKDF2", false, ["deriveBits", "deriveKey"]);
+  return window.crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt: salt, iterations: 100000, hash: "SHA-256" },
+    keyMaterial,
+    { name: "AES-GCM", length: 256},
+    true,
+    [ "encrypt", "decrypt" ]
+  );
+}
+const IV_LENGTH = 12;  /// 96 bits
+async function encrypt(plaintext, key) {
+  let iv = window.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  let ciphertext = await window.crypto.subtle.encrypt({ name: "AES-GCM", iv: iv }, key, new TextEncoder().encode(plaintext));
+  return btoa(String.fromCharCode(...iv,...new Uint8Array(ciphertext)));  // base64
+}
+async function decrypt(bufferEncoded, key) {
+  let buffer = Uint8Array.from(atob(bufferEncoded), c => c.charCodeAt(0))  //base64
+  return new TextDecoder().decode(await window.crypto.subtle.decrypt({ name: "AES-GCM", iv: buffer.subarray(0, IV_LENGTH) }, key, buffer.subarray(IV_LENGTH)));
+}

--- a/index.php
+++ b/index.php
@@ -7,6 +7,10 @@ $base_url = getenv('MWN_BASE_URL') ?: 'https://notes.orga.cat';
 // Should be outside of the document root, if possible.
 $save_path = getenv('MWN_SAVE_PATH') ?: '_tmp';
 
+// Salt for encryption
+$encryption = getenv('MWN_ENCRYPTION') ?: false;
+$salt = getenv('MWN_CRYPTO_SALT') ?: 'c36g0bZfykx254eyzQNZ8SNR0gT78D89';
+
 // Disable caching.
 header('Cache-Control: no-cache, no-store, must-revalidate');
 header('Pragma: no-cache');
@@ -16,7 +20,7 @@ header('Expires: 0');
 if (!isset($_GET['note']) || !preg_match('/^[a-zA-Z0-9_-]+$/', $_GET['note']) || strlen($_GET['note']) > 64) {
 
     // Generate a name with 5 random unambiguous characters. Redirect to it.
-    header("Location: $base_url/" . substr(str_shuffle('234579abcdefghjkmnpqrstwxyz'), -5));
+    header("Location: $base_url/" . substr(str_shuffle(str_repeat('23456789abcdefghjkmnpqrstwxyz', 5)), -5));
     die;
 }
 
@@ -63,6 +67,11 @@ if (isset($_GET['raw']) || strpos($_SERVER['HTTP_USER_AGENT'], 'curl') === 0) {
         ?></textarea>
     </div>
     <pre id="printable"></pre>
+    <script type="text/javascript">const CRYPT_ENABLED = <?php print $encryption ? "true" : "false"; ?>;</script>
+    <?php if ($encryption) : ?>
+        <script type="text/javascript">const SALT = "<?php print $salt; ?>";</script>
+        <script src="<?php print $base_url; ?>/crypt.js"></script>
+    <?php endif; ?>
     <script src="<?php print $base_url; ?>/script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,12 +1,16 @@
 /*! Minimalist Web Notepad | https://github.com/pereorga/minimalist-web-notepad */
 
-function uploadContent() {
+async function uploadContent() {
 
     // If textarea value changes.
     if (content !== textarea.value) {
         var temp = textarea.value;
-        var request = new XMLHttpRequest();
 
+        // Make the content available to print.
+        printable.removeChild(printable.firstChild);
+        printable.appendChild(document.createTextNode(temp));
+
+        var request = new XMLHttpRequest();
         request.open('POST', window.location.href, true);
         request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
         request.onload = function() {
@@ -22,11 +26,7 @@ function uploadContent() {
             // Try again after 1 second.
             setTimeout(uploadContent, 1000);
         }
-        request.send('text=' + encodeURIComponent(temp));
-
-        // Make the content available to print.
-        printable.removeChild(printable.firstChild);
-        printable.appendChild(document.createTextNode(temp));
+        request.send('text=' + encodeURIComponent(CRYPT_ENABLED ? await encrypt(temp, key) : temp));
     }
     else {
 
@@ -37,11 +37,27 @@ function uploadContent() {
 
 
 // Run when DOM is loaded
-var content, printable, textarea;
-window.onload = function() {
+let content, key, salt, printable, textarea;
+window.onload = async function() {
     textarea = document.getElementById('content');
     printable = document.getElementById('printable');
-    content = textarea.value
+
+    // Setup encryption
+    if (CRYPT_ENABLED) {
+        salt = new TextEncoder().encode(SALT);
+        if (!window.location.hash) {
+            window.location.hash = await generatePassword(16);
+        }
+        key = await deriveKey(window.location.hash.substr(1), salt);
+        if (textarea.value) {
+            try {
+                textarea.value = await decrypt(textarea.value, key);
+            } catch(e) {
+                textarea.value = 'Unable to decrypt note. Please append the correct password to the URL "#<password>" and reload.';
+            }
+        }
+    }
+    content = textarea.value;
 
     // Make the content available to print.
     printable.appendChild(document.createTextNode(content));

--- a/script.js
+++ b/script.js
@@ -35,12 +35,17 @@ function uploadContent() {
     }
 }
 
-var textarea = document.getElementById('content');
-var printable = document.getElementById('printable');
-var content = textarea.value;
 
-// Make the content available to print.
-printable.appendChild(document.createTextNode(content));
+// Run when DOM is loaded
+var content, printable, textarea;
+window.onload = function() {
+    textarea = document.getElementById('content');
+    printable = document.getElementById('printable');
+    content = textarea.value
 
-textarea.focus();
-uploadContent();
+    // Make the content available to print.
+    printable.appendChild(document.createTextNode(content));
+
+    textarea.focus();
+    uploadContent();
+}


### PR DESCRIPTION
Cryptography
- Use AES-GCM-256 for encryption
- Use PBKDF2 with SHA-256 and 100000 iterations for key derivation

Environment variables
- Enable with environment variable `MWN_ENCRYPTION`
- Set salt with environment variable `MWN_CRYPTO_SALT`

Behavior
- A human-readable password (16 characters) will be automatically be generated for empty notes
- The password will be appended to the URI as fragment `#password`
- The IV (12 bytes) is prepended to the ciphertext
- Everything is base64 encoded (33% overhead)

Documentation
- Add section about environment variables to `README.md`

Fixes
- Fix note identifier generation such that characters can appear multiple times

Fixes #41 